### PR TITLE
Reorganize responsibilities and add in-memory code swapping for hot reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ environment via `fig up` assuming you have the right options configured (see bel
 
 ## Usage
 
-From the project root you can execute `lein run` to start the service.
+From the project root you can execute `lein trampoline run main` to start the service.  If using
+fig/docker `fig up` should get you going (note this will default to a development environment).
 
 Interaction with the service is done over HTTP via standard HTTP verbs:
 
@@ -45,7 +46,7 @@ Options are configured via environment variables. Options below are also referen
 * First start the service
 
 ```shell
-FILE_STORAGE_PATH=/tmp BUCKET_STORAGE_MAP="{:some-bucket :file}" HTTP_PORT=3000 lein run
+FILE_STORAGE_PATH=/tmp BUCKET_STORAGE_MAP="{:some-bucket :file}" SERVER_PORT=3000 lein trampoline run main
 ```
 
 * Next you can use any HTTP client to interact, like `curl`
@@ -66,11 +67,56 @@ The only notes with docker are port and volume mappings.
 * **Volumes**: If you want to serve a local directory via the docker instance you need to map the local volume to a folder in the docker container and then configure the `FILE_STORAGE_PATH` as the same folder within the docker container.
   * For example, if instantiating a volume mapping as `-v /path/to/local/storage:/storage` then be sure that `FILE_STORAGE_PATH=/storage`.
 
-### Bugs
+## Development
+
+Developing against this is pretty easy.  When starting the server instead of executing the `main` task
+you specify `dev` instead which will start up an nREPL on port 7888 and add some helpful functions to
+the `user` namespace so you can reload the application after making source changes without reloading
+the whole JVM process!  Here's a quick example:
+
+#### First start the server in dev mode (in a separate tab or background)
+```shell
+lein trampoline run dev &
+```
+_Fig/Docker_
+```shell
+fig up -d
+```
+
+#### Now fire up a REPL client
+_Using Leiningen's repl_
+```
+lein repl :connect 7888
+Connecting to nREPL at 127.0.0.1:7888
+REPL-y 0.3.5, nREPL 0.2.6
+Clojure 1.6.0
+OpenJDK 64-Bit Server VM 1.7.0_65-b32
+    Docs: (doc function-name-here)
+          (find-doc "part-of-name-here")
+  Source: (source function-name-here)
+ Javadoc: (javadoc java-object-or-class-here)
+    Exit: Control+D or (exit) or (quit)
+ Results: Stored in vars *1, *2, *3, an exception in *e
+```
+
+_From here you can inspect the current instance via `!app` and reload the whole application (including code changes) via `reload-app!`_
+```
+user=> !app
+#<Ref@677c2c46: {:context {:storage #<store$gen_storage_proxy$reify__6557 storage.store$gen_storage_proxy$reify__6557@24ad3488>, :memcached nil}, :handler #<not_modified$wrap_not_modified$fn__2070 ring.middleware.not_modified$wrap_not_modified$fn__2070@33784d10>, :server #<clojure.lang.AFunction$1@4140e6f8>, :stop! #<core$reify__6639$fn__6640 storage.core$reify__6639$fn__6640@3e52f2e5>, :app #<core$reify__6639 storage.core$reify__6639@5abf3952>}>
+user=> reload-app!
+#<core$bind_user_tools_BANG_$fn__6662 storage.core$bind_user_tools_BANG_$fn__6662@9c7edce>
+user=> (reload-app!)
+Shutting down http storage server at Thu Dec 04 21:36:50 UTC 2014!
+:reloading (storage.core storage.core-test)
+Starting http storage server at Thu Dec 04 21:36:50 UTC 2014!
+{:context {:storage #<store$gen_storage_proxy$reify__6557 storage.store$gen_storage_proxy$reify__6557@6cbc461a>, :memcached nil}, :handler #<not_modified$wrap_not_modified$fn__2070 ring.middleware.not_modified$wrap_not_modified$fn__2070@3c9e8cbb>, :server #<clojure.lang.AFunction$1@4d296814>, :stop! #<core$reify__7089$fn__7090 storage.core$reify__7089$fn__7090@506dd498>, :app #<core$reify__7089 storage.core$reify__7089@5b33ea53>}
+```
+
+## Bugs
 
 ...
 
-### Thanks
+## Thanks
 
 Thanks to all of the amazing work of clojure and java developers upon which this is built. It
 took very little means to put this together due to the power and simplicity of the toolsets.

--- a/fig.yml
+++ b/fig.yml
@@ -1,9 +1,10 @@
-web:
+http:
   build: .
   working_dir: /usr/src/app
-  command: lein run
+  command: lein trampoline run dev
   ports:
    - "3000:3000"
+   - "7888:7888"
   volumes:
    - .:/usr/src/app
    - tmp/dev:/storage

--- a/project.clj
+++ b/project.clj
@@ -13,8 +13,11 @@
                  [javax.servlet/servlet-api "2.5"]
                  [clojurewerkz/spyglass "1.1.0"]
                  [environ "1.0.0"]
-                 [clj-aws-s3 "0.3.10" :exclusions [joda-time]]]
+                 [clj-aws-s3 "0.3.10" :exclusions [joda-time]]
+                 [org.clojure/tools.nrepl "0.2.3"]
+                 [org.clojure/tools.namespace "0.2.4"]]
   :plugins [[lein-environ "1.0.0"]]
+  :app-class storage.core/app
   :main ^:skip-aot storage.core
-  :target-path "target/%s"
+  :target-path "tmp/"
   :profiles {:uberjar {:aot :all}})

--- a/src/storage/nrepl.clj
+++ b/src/storage/nrepl.clj
@@ -1,0 +1,9 @@
+(ns ^{:clojure.tools.namespace.repl/load false}
+    storage.nrepl
+    (:require [clojure.tools.nrepl.server :as nrepl]
+              [clojure.java.io :as io]))
+
+(defn start-nrepl! []
+  (let [nrepl-port 7888]
+    (nrepl/start-server :port nrepl-port)
+    (println (str "Started nREPL server, port " nrepl-port))))


### PR DESCRIPTION
This is a huge refactor of the code's organizational structure and the
way an app is instantiated and managed.  Instead of creating a single app
that can only be re-created by tearing down and reloading the whole JVM
and associated stack we can use some of clojure's built-in namespace tools
to reload our own code interactively.  This makes it a lot easier to quickly
test changes and also encourages experimentation within the REPL as a standard
part of the development workflow.

Note that this is pretty rough and will be cleaned up more in future commits.
Eventually this should live as a leiningen template for reloadable apps.
